### PR TITLE
Add Dec 2025 NPort report to Reports section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1000,6 +1000,7 @@ document.getElementById("chat-icon").addEventListener("click", function() {
 <div class="documentDownWrap">
 <h2>Reports</h2>
 <div class="docRowWp">
+<div class="docRowDT"><a href="https://www.gham.co/assets/pdfs/GHTA_NPort_123125.pdf" target="_blank"><img src="assets/images/icon-pdf.svg"/>Dec 2025 NPort</a>
 <div class="docRowDT"><a href="https://www.gham.co/assets/pdfs/GH_063025_NPort.pdf" target="_blank"><img src="assets/images/icon-pdf.svg"/>June 2025 NPort</a>
 <div class="docRowDT"><a href="https://www.gham.co/assets/pdfs/GH_Dec2024_SOI.pdf" target="_blank"><img src="assets/images/icon-pdf.svg"/>SOI Report-Dec2024</a>
 <div class="docRowDT"><a href="https://www.gham.co/assets/pdfs/GHTA_JUN2024_SOI.pdf" target="_blank"><img src="assets/images/icon-pdf.svg"/>SOI Report-June2024</a>


### PR DESCRIPTION
## Summary
Added the December 2025 NPort report link to the Reports section on the homepage.

## Changes
- Added new document row linking to the December 2025 NPort PDF report (`GHTA_NPort_123125.pdf`)
- Positioned as the most recent report at the top of the Reports list, above the June 2025 NPort report
- Follows existing document row styling and structure with PDF icon

## Details
The new report entry maintains consistency with the existing report format and is placed chronologically as the latest available NPort report.

https://claude.ai/code/session_01DBjzfVUheAKShCtAsTHWPa