### PR TITLE
Update GitHub Actions workflows: upgrade actions and Python version

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -9,15 +9,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: checkout repo content
-        uses: actions/checkout@main # checkout the repository content to github runner.
-        
+        uses: actions/checkout@v4 # checkout the repository content to github runner.
+
       - name: setup python
-        uses: actions/setup-python@main
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8 #install the python needed
+          python-version: '3.12' #install the python needed
           
       - name: install packages
         run: |
@@ -36,7 +38,7 @@ jobs:
           git config --local user.email "actions@github.com"
           git add assets/js/*
           git add assets/old_cache.txt
-          git pull
+          git pull --rebase origin main
           git status
           if git diff --cached --quiet; then
             echo "No new data from API, skipping commit."

--- a/.github/workflows/monthlyrun.yml
+++ b/.github/workflows/monthlyrun.yml
@@ -7,15 +7,17 @@ on:
 jobs:
   update-financial-returns:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repo content
-        uses: actions/checkout@main
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@main
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Install required packages
         run: |
@@ -31,7 +33,7 @@ jobs:
           git config --local user.name actions-user
           git config --local user.email "actions@github.com"
           git add index.html
-          git pull
+          git pull --rebase origin main
           git status
           git diff --cached --exit-code || git commit -m "GH ACTION Monthly Financial Returns Update $(date)"
           git push origin main

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -7,15 +7,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: checkout repo content
-        uses: actions/checkout@main # checkout the repository content to github runner.
-        
+        uses: actions/checkout@v4 # checkout the repository content to github runner.
+
       - name: setup python
-        uses: actions/setup-python@main
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8 #install the python needed
+          python-version: '3.12' #install the python needed
           
       - name: install packages
         run: |
@@ -34,7 +36,7 @@ jobs:
           git config --local user.email "actions@github.com"
           git add assets/js/*
           git add assets/old_cache.txt
-          git pull
+          git pull --rebase origin main
           git status
           if git diff --cached --quiet; then
             echo "No new data from API, skipping commit."


### PR DESCRIPTION
## Summary
This PR updates all GitHub Actions workflows to use current versions of actions and upgrades the Python runtime version for improved security and compatibility.

## Key Changes
- **Action versions**: Updated `actions/checkout` from `main` to `v4` and `actions/setup-python` from `main` to `v5` across all three workflows (manual.yml, pythonapp.yml, monthlyrun.yml)
- **Python version**: Upgraded Python from 3.8/3.10 to 3.12 consistently across all workflows
- **Permissions**: Added explicit `contents: write` permission to all job definitions to enable git operations
- **Git operations**: Updated `git pull` commands to use `git pull --rebase origin main` for more predictable merge behavior
- **Code formatting**: Fixed trailing whitespace inconsistencies in workflow files

## Implementation Details
- Using pinned action versions (v4, v5) instead of `main` branch references ensures reproducible builds and prevents unexpected breaking changes
- Python 3.12 provides better performance and security updates compared to earlier versions
- The `--rebase` flag prevents merge commits and maintains a cleaner git history when pulling changes before pushing
- Explicit `contents: write` permission declaration follows GitHub's principle of least privilege for workflow permissions
