### PR TITLE
ci: pull before staging so rebase has a clean index

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -36,9 +36,9 @@ jobs:
         run: |
           git config --local user.name actions-user
           git config --local user.email "actions@github.com"
+          git pull --rebase --autostash origin main
           git add assets/js/*
           git add assets/old_cache.txt
-          git pull --rebase origin main
           git status
           if git diff --cached --quiet; then
             echo "No new data from API, skipping commit."

--- a/.github/workflows/monthlyrun.yml
+++ b/.github/workflows/monthlyrun.yml
@@ -32,8 +32,8 @@ jobs:
         run: |
           git config --local user.name actions-user
           git config --local user.email "actions@github.com"
+          git pull --rebase --autostash origin main
           git add index.html
-          git pull --rebase origin main
           git status
           git diff --cached --exit-code || git commit -m "GH ACTION Monthly Financial Returns Update $(date)"
           git push origin main

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -34,9 +34,9 @@ jobs:
         run: |
           git config --local user.name actions-user
           git config --local user.email "actions@github.com"
+          git pull --rebase --autostash origin main
           git add assets/js/*
           git add assets/old_cache.txt
-          git pull --rebase origin main
           git status
           if git diff --cached --quiet; then
             echo "No new data from API, skipping commit."


### PR DESCRIPTION
Follow-up to #9.

The morning run failed with:

```
error: cannot pull with rebase: Your index contains uncommitted changes.
error: Please commit or stash them.
```

`git pull --rebase` refuses to run with a dirty index, unlike the default merge-based pull that the workflows previously used. The fix reorders the commit step so the pull happens before any `git add`, and adds `--autostash` to cover stray modifications from the python step.

Applied to all three workflows: `pythonapp.yml`, `manual.yml`, `monthlyrun.yml`.
