### PR TITLE
Update PDF document links in Reports section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1010,9 +1010,9 @@ document.getElementById("chat-icon").addEventListener("click", function() {
 <a href="https://www.gham.co/assets/pdfs/GH_123121_bannerless.pdf" target="_blank"><img src="assets/images/icon-pdf.svg"/>SOI Report-Dec2021</a>
 <a href="https://www.gham.co/assets/pdfs/GH%2012.31.22%20SOI.pdf" target="_blank"><img src="assets/images/icon-pdf.svg"/>SOI Report-Dec2022</a>
 </div>
-<div class="docRowDT"><a href="https://www.gham.co/assets/pdfs/TSR_GHTAETF.pdf" target="_blank"><img src="assets/images/icon-pdf.svg"/>TSR</a></div>
+<div class="docRowDT"><a href="https://www.gham.co/assets/pdfs/GHTA_TSR_033126.pdf" target="_blank"><img src="assets/images/icon-pdf.svg"/>TSR</a></div>
 <div class="docRowDT"><a href="https://www.gham.co/assets/pdfs/GHTA_9.30.24.pdf" target="_blank"><img src="assets/images/icon-pdf.svg"/>Annual Report</a></div>
-<div class="docRowDT"><a href="https://www.gham.co/assets/pdfs/GH_Semi_033125_Final.pdf" target="_blank"><img src="assets/images/icon-pdf.svg"/>Semi-Annual Report</a></div>
+<div class="docRowDT"><a href="https://www.gham.co/assets/pdfs/Goose%20Hollow_SAR_033126_Final.pdf" target="_blank"><img src="assets/images/icon-pdf.svg"/>Semi-Annual Report</a></div>
 <div class="docRowDT"><a href="https://www.gham.co/assets/pdfs/Goose Hollow_AR_093025_Final.pdf" target="_blank"><img src="assets/images/icon-pdf.svg"/>Annual Financial Statements and Other Information</a></div>
 </div>
 </div>


### PR DESCRIPTION
## Summary
Updated the file paths for two PDF documents in the Reports section to point to newer versions with current dates.

## Key Changes
- **TSR Report**: Updated link from `TSR_GHTAETF.pdf` to `GHTA_TSR_033126.pdf` to reference the March 31, 2026 version
- **Semi-Annual Report**: Updated link from `GH_Semi_033125_Final.pdf` to `Goose%20Hollow_SAR_033126_Final.pdf` to reference the March 31, 2026 version with standardized naming convention

## Details
These changes reflect updated document versions with more recent reporting dates (033126 = March 31, 2026). The Semi-Annual Report filename was also standardized to use the full "Goose Hollow" naming convention consistent with other financial documents on the page.
